### PR TITLE
feat(frontend): 优化历史记录和主视图中的 UI 布局和样式

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -35,11 +35,9 @@
 
     <!-- 主内容区 -->
     <main class="layout-main">
-      <RouterView v-slot="{ Component, route }">
-        <component :is="Component" />
-
-        <!-- 全局页脚版权信息（首页除外） -->
-        <footer v-if="route.path !== '/'" class="global-footer">
+      <router-view :key="$route.fullPath"/>
+      <!-- 全局页脚版权信息（首页除外） -->
+        <footer v-if="$route.path !== '/'" class="global-footer">
           <div class="footer-content">
             <div class="footer-text">
               © 2025 <a href="https://github.com/HisMax/RedInk" target="_blank" rel="noopener noreferrer">RedInk</a> by 默子 (Histone)
@@ -49,15 +47,15 @@
             </div>
           </div>
         </footer>
-      </RouterView>
     </main>
   </div>
 </template>
 
 <script setup lang="ts">
-import { RouterView, RouterLink } from 'vue-router'
+import { RouterView, RouterLink, } from 'vue-router'
 import { onMounted } from 'vue'
 import { setupAutoSave } from './stores/generator'
+
 
 // 启用自动保存到 localStorage
 onMounted(() => {

--- a/frontend/src/assets/css/base.css
+++ b/frontend/src/assets/css/base.css
@@ -103,6 +103,7 @@ body {
 /* 通用容器 */
 .container {
   max-width: 1200px;
+  min-height: calc(100vh - 300px);
   margin: 0 auto;
 }
 
@@ -120,8 +121,6 @@ body {
   font-size: 36px;
   font-weight: 800;
   color: var(--text-main);
-  margin-bottom: 12px;
-  letter-spacing: -1px;
 }
 
 .page-subtitle {

--- a/frontend/src/assets/css/components.css
+++ b/frontend/src/assets/css/components.css
@@ -224,7 +224,7 @@
 .modal-fullscreen {
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.9);
+  background: rgba(0,0,0,0.5);
   z-index: 999;
   display: flex;
   align-items: center;

--- a/frontend/src/assets/css/history.css
+++ b/frontend/src/assets/css/history.css
@@ -8,7 +8,7 @@
 
 .stat-box {
   background: white;
-  padding: 24px;
+  padding: 24px 61px;
   border-radius: 16px;
   display: flex;
   align-items: center;
@@ -265,7 +265,6 @@
 
 /* Modal Gallery Grid (History specific) */
 .modal-gallery-grid {
-  flex: 1;
   overflow-y: auto;
   padding: 20px;
   display: grid;

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -204,7 +204,7 @@
                 </button>
               </div>
             </div>
-            <div style="display: flex; gap: 12px; align-items: flex-start;">
+            <div style="display: flex; gap: 12px; align-items: center;">
               <button class="btn" @click="downloadAllImages" style="padding: 8px 16px; font-size: 14px;">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 6px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
                 打包下载
@@ -216,7 +216,7 @@
           <div class="modal-gallery-grid">
              <div v-for="(img, idx) in viewingRecord.images.generated" :key="idx" class="modal-img-item">
                 <!-- 图片预览区域 -->
-                <div class="modal-img-preview" v-if="img">
+                <div class="modal-img-preview" v-if="img" :class="{regenerateIng: regeneratingImages.has(idx) }">
                   <img
                     :src="`/api/images/${viewingRecord.images.task_id}/${img}`"
                     loading="lazy"
@@ -229,7 +229,7 @@
                       @click="regenerateHistoryImage(idx)"
                       :disabled="regeneratingImages.has(idx)"
                     >
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <svg class="spin-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M23 4v6h-6"></path>
                         <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
                       </svg>
@@ -271,9 +271,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { getHistoryList, getHistoryStats, searchHistory, deleteHistory, getHistory, type HistoryRecord, regenerateImage as apiRegenerateImage, updateHistory, scanAllTasks } from '../api'
+import { getHistoryList, getHistoryStats, searchHistory, deleteHistory, getHistory, type HistoryRecord, regenerateImage as apiRegenerateImage, updateHistory, scanAllTasks, regenerateImage } from '../api'
 import { useGeneratorStore } from '../stores/generator'
 
 const router = useRouter()
@@ -574,6 +574,7 @@ onMounted(async () => {
   }
 }
 
+
 /* Toolbar */
 .toolbar-wrapper {
   display: flex;
@@ -807,7 +808,7 @@ onMounted(async () => {
 .modal-fullscreen {
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.9);
+  background: rgba(0,0,0,0.5);
   z-index: 999;
   display: flex;
   align-items: center;
@@ -855,7 +856,6 @@ onMounted(async () => {
 
 .modal-title.collapsed {
   display: -webkit-box;
-  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -962,7 +962,6 @@ onMounted(async () => {
 .original-input-text.collapsed {
   max-height: 4.8em; /* 约3行 */
   display: -webkit-box;
-  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -997,7 +996,6 @@ onMounted(async () => {
 }
 
 .modal-gallery-grid {
-  flex: 1;
   overflow-y: auto;
   padding: 20px;
   display: grid;
@@ -1038,6 +1036,14 @@ onMounted(async () => {
 .modal-img-preview:hover .modal-img-overlay {
   opacity: 1;
   pointer-events: auto;
+}
+.regenerateIng .modal-img-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.regenerateIng .spin-icon {
+  animation: spin 1s linear infinite;
 }
 
 .modal-overlay-btn {

--- a/frontend/src/views/OutlineView.vue
+++ b/frontend/src/views/OutlineView.vue
@@ -124,6 +124,12 @@ const addPage = (type: 'cover' | 'content' | 'summary') => {
 }
 
 const goBack = () => {
+  // 如果有足够的 history，可以回退
+  if (window.history.length > 1) {
+    router.back()
+    return
+  }
+  // 否则兜底到首页
   router.push('/')
 }
 

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -45,7 +45,7 @@
             <div class="col-status">
               <span
                 v-if="textConfig.active_provider === name"
-                class="status-badge active"
+                class="seeting-status-badge active"
               >
                 已激活
               </span>
@@ -125,7 +125,7 @@
             <div class="col-status">
               <span
                 v-if="imageConfig.active_provider === name"
-                class="status-badge active"
+                class="seeting-status-badge active"
               >
                 已激活
               </span>
@@ -675,7 +675,8 @@ onMounted(() => {
 
 .table-header {
   display: grid;
-  grid-template-columns: 90px 1fr 100px 1fr 80px;
+  /* 列宽比例：1, 2, 3, 4, 1 */
+  grid-template-columns: 1fr 2fr 3fr 4fr 1fr;
   gap: 12px;
   padding: 12px 16px;
   background: #f9fafb;
@@ -689,7 +690,8 @@ onMounted(() => {
 
 .table-row {
   display: grid;
-  grid-template-columns: 90px 1fr 100px 1fr 80px;
+  /* 与表头保持一致的列宽比例 */
+  grid-template-columns: 1fr 2fr 3fr 4fr 1fr;
   gap: 12px;
   padding: 14px 16px;
   border-bottom: 1px solid #e5e7eb;
@@ -709,8 +711,11 @@ onMounted(() => {
   background: #fef2f2;
 }
 
+.col-status {
+  position: relative;
+}
 /* 状态相关 */
-.status-badge {
+.seeting-status-badge {
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
@@ -719,7 +724,7 @@ onMounted(() => {
   font-weight: 500;
 }
 
-.status-badge.active {
+.seeting-status-badge.active {
   background: #dcfce7;
   color: #166534;
 }
@@ -758,6 +763,7 @@ onMounted(() => {
   font-size: 12px;
   font-family: 'Monaco', 'Menlo', monospace;
   color: #6b7280;
+  word-break: break-all;
 }
 
 .apikey-masked.empty {


### PR DESCRIPTION
简化 App.vue 中的 router-view 并调整页脚条件
在 base.css 中为容器添加最小高度并移除标题边距
降低模态框背景透明度以提高可见性
在 history.css 中更新内边距并移除弹性属性
在 HistoryView.vue 中对齐元素并添加重新生成指示器