### PR TITLE
fix: replace 1 bare except clauses with except Exception

### DIFF
--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -465,7 +465,7 @@ class HistoryService:
             def get_index(filename):
                 try:
                     return int(filename.split('.')[0])
-                except:
+                except Exception:
                     return 999
 
             image_files.sort(key=get_index)


### PR DESCRIPTION
## What
Replace 1 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.